### PR TITLE
しりとり、まんだらのテーマ一覧のActivityを追加し、遷移できるように作成

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
         </activity>
         <activity android:name=".MainActivity">
         </activity>
+        <activity android:name=".ThemeList">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/fastidea_android/ThemeList.kt
+++ b/app/src/main/java/com/example/fastidea_android/ThemeList.kt
@@ -1,0 +1,27 @@
+package com.example.fastidea_android
+
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+import android.view.MenuItem
+import kotlinx.android.synthetic.main.activity_theme_list.*
+
+class ThemeList : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_theme_list)
+
+        methodName.text = intent.getStringExtra(TopPage.METHODNAME)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = "ThemeList"
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        when (item?.itemId) {
+            android.R.id.home -> finish()
+            else -> return super.onOptionsItemSelected(item)
+        }
+        return true
+    }
+}

--- a/app/src/main/java/com/example/fastidea_android/ThemeList.kt
+++ b/app/src/main/java/com/example/fastidea_android/ThemeList.kt
@@ -11,12 +11,18 @@ class ThemeList : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_theme_list)
 
+        // トップ画面からの遷移時に受け取ったMETHODNAMEを取得
         methodName.text = intent.getStringExtra(TopPage.METHODNAME)
 
+        // 上のバーの左端に戻るボタンを表示
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        // METHODNAMEを取得出来たかの確認用
+        // TODO:実装が進んだら消す
         supportActionBar?.title = "ThemeList"
     }
 
+    // 上のバーの戻るボタンの処理
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         when (item?.itemId) {
             android.R.id.home -> finish()

--- a/app/src/main/java/com/example/fastidea_android/TopPage.kt
+++ b/app/src/main/java/com/example/fastidea_android/TopPage.kt
@@ -15,12 +15,15 @@ class TopPage : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_top_page)
 
+        // 「しりとり」ボタンタップ時の処理
         toSiritoriThemeListButton.setOnClickListener {
+            // テーマ一覧のActivityにMETHODNAMEを渡して遷移
             val intent = Intent(this, ThemeList::class.java)
             intent.putExtra(METHODNAME, "Siritori")
             startActivity(intent)
         }
 
+        //「まんだら」ボタンタップ時の処理
         toMandaraThemeList.setOnClickListener {
             val intent = Intent(this, ThemeList::class.java)
             intent.putExtra(METHODNAME, "Mandara")

--- a/app/src/main/java/com/example/fastidea_android/TopPage.kt
+++ b/app/src/main/java/com/example/fastidea_android/TopPage.kt
@@ -1,12 +1,30 @@
 package com.example.fastidea_android
 
+import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import kotlinx.android.synthetic.main.activity_top_page.*
 
 class TopPage : AppCompatActivity() {
+    companion object {
+        const val METHODNAME = "com.fastIdea.methodName"
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_top_page)
+
+        toSiritoriThemeListButton.setOnClickListener {
+            val intent = Intent(this, ThemeList::class.java)
+            intent.putExtra(METHODNAME, "Siritori")
+            startActivity(intent)
+        }
+
+        toMandaraThemeList.setOnClickListener {
+            val intent = Intent(this, ThemeList::class.java)
+            intent.putExtra(METHODNAME, "Mandara")
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/res/layout/activity_theme_list.xml
+++ b/app/src/main/res/layout/activity_theme_list.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ThemeList">
+
+    <TextView
+            android:text="TextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" tools:layout_editor_absoluteY="332dp"
+            tools:layout_editor_absoluteX="176dp" android:id="@+id/methodName"/>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_top_page.xml
+++ b/app/src/main/res/layout/activity_top_page.xml
@@ -18,7 +18,7 @@
     <Button
             android:text="しりとり"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" android:id="@+id/button"
+            android:layout_height="wrap_content" android:id="@+id/toSiritoriThemeListButton"
             android:layout_marginTop="70dp"
             app:layout_constraintTop_toBottomOf="@+id/textView" app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintHorizontal_bias="0.5" app:layout_constraintEnd_toEndOf="parent"
@@ -26,15 +26,15 @@
     <Button
             android:text="まんだら"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" android:id="@+id/button2"
+            android:layout_height="wrap_content" android:id="@+id/toMandaraThemeList"
             app:layout_constraintEnd_toEndOf="parent" app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintHorizontal_bias="0.5" android:layout_marginTop="100dp"
-            app:layout_constraintTop_toBottomOf="@+id/button"/>
+            app:layout_constraintTop_toBottomOf="@+id/toSiritoriThemeListButton"/>
     <Button
             android:text="チュートリアル"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" android:id="@+id/button3"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginTop="100dp" app:layout_constraintTop_toBottomOf="@+id/button2"
+            android:layout_marginTop="100dp" app:layout_constraintTop_toBottomOf="@+id/toMandaraThemeList"
             app:layout_constraintHorizontal_bias="0.5" app:layout_constraintEnd_toEndOf="parent"/>
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
###  やったこと
- しりとり、まんだらで共通のテーマ一覧のActivityを追加
- 上記のActivityに遷移できるように作成
- 遷移する時にMethod名を渡すように設定

### この先
- 渡されたMethod名によって表示するテーマ一覧を変更する