### PR TITLE
しりとり法のメイン画面にキーワードとアイデアを表示する土台を作成

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
 }

--- a/app/src/main/java/com/example/fastidea_android/Siritori.kt
+++ b/app/src/main/java/com/example/fastidea_android/Siritori.kt
@@ -2,12 +2,39 @@ package com.example.fastidea_android
 
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.widget.LinearLayoutManager
+import android.view.View
+import android.widget.Button
+import android.widget.Toast
 import com.example.fastidea_android.R
+import kotlinx.android.synthetic.main.activity_siritori.*
 
-class Siritori : AppCompatActivity() {
+class Siritori : AppCompatActivity(), SiritoriMainListViewHolder.CellTappedListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_siritori)
+
+        // RecycleViewの初期設定
+        siritori_main_recycler.adapter = SiritoriMainListViewAdapter(this.createDataList(),this)
+        siritori_main_recycler.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
+    }
+
+    private fun createDataList(): List<SiritoriMainData> {
+
+        // TODO:Realmから呼び出したデータを格納する
+        val dataList = mutableListOf<SiritoriMainData>()
+        for (i in 0..49) {
+            val data = SiritoriMainData()
+            data.keyWord = i.toString() + "番目のキーワード"
+            data.idea = i.toString() + "番目のアイデア"
+            dataList.add(data)
+        }
+        return dataList
+    }
+
+    // 各Cellをタップした時の処理
+    override fun onCellTapped(tappedView: View, data: SiritoriMainData) {
+        Toast.makeText(applicationContext, "position" + data.idea + "was tapped", Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/example/fastidea_android/SiritoriMainListViewAdapter.kt
+++ b/app/src/main/java/com/example/fastidea_android/SiritoriMainListViewAdapter.kt
@@ -1,0 +1,29 @@
+package com.example.fastidea_android
+
+import android.support.v7.widget.RecyclerView
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+
+class SiritoriMainListViewAdapter(private val mainList: List<SiritoriMainData>, private val listener: SiritoriMainListViewHolder.CellTappedListener) : RecyclerView.Adapter<SiritoriMainListViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SiritoriMainListViewHolder {
+        val rowView: View = LayoutInflater.from(parent.context).inflate(R.layout.siritori_main_list_cell, parent, false)
+        return SiritoriMainListViewHolder(rowView)
+    }
+
+    override fun onBindViewHolder(holder: SiritoriMainListViewHolder, position: Int) {
+        // EditTextの初期値を設定
+        holder.keywordView.setText(mainList[position].keyWord, TextView.BufferType.NORMAL)
+        holder.ideaView.setText(mainList[position].idea, TextView.BufferType.NORMAL)
+        holder.itemView.setOnClickListener {
+            listener.onCellTapped(it, mainList[position])
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return mainList.size
+    }
+}

--- a/app/src/main/java/com/example/fastidea_android/SiritoriMainListViewHolder.kt
+++ b/app/src/main/java/com/example/fastidea_android/SiritoriMainListViewHolder.kt
@@ -1,0 +1,16 @@
+package com.example.fastidea_android
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.widget.EditText
+
+class SiritoriMainListViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView){
+
+    // インターフェースを切っておく、実処理はSiritoriActivityで書く
+    interface CellTappedListener {
+        fun onCellTapped(tappedView: View, data: SiritoriMainData)
+    }
+
+    val keywordView: EditText = itemView.findViewById(R.id.siritori_keyword)
+    val ideaView: EditText = itemView.findViewById(R.id.siritori_idea)
+}

--- a/app/src/main/java/com/example/fastidea_android/SiritoriObj.kt
+++ b/app/src/main/java/com/example/fastidea_android/SiritoriObj.kt
@@ -1,5 +1,6 @@
 package com.example.fastidea_android
 
+import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import io.realm.annotations.Required
@@ -11,4 +12,19 @@ open class SiritoriObj : RealmObject() {
     @Required
     open var theme : String = ""
 
+}
+
+open class SiritoriMainList : RealmObject() {
+    @PrimaryKey
+    open var id : Int? = null
+
+    open var SiritoriMainDataList: RealmList<SiritoriMainData>? = null
+}
+
+open class SiritoriMainData : RealmObject() {
+    @PrimaryKey
+    open var id : Int? = null
+
+    open var keyWord : String = ""
+    open var idea : String = ""
 }

--- a/app/src/main/res/layout/activity_siritori.xml
+++ b/app/src/main/res/layout/activity_siritori.xml
@@ -6,14 +6,11 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".Siritori">
-
-    <TextView
-            android:text="しりとり方の画面"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/textView3" app:layout_constraintTop_toTopOf="parent"
-            android:layout_marginTop="355dp" app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginStart="176dp" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginEnd="176dp" android:layout_marginBottom="357dp"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+    <android.support.v7.widget.RecyclerView
+            android:layout_width="395dp"
+            android:layout_height="715dp" app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginTop="8dp" app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginStart="8dp" android:layout_marginEnd="8dp" app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" android:layout_marginBottom="8dp"
+            android:id="@+id/siritori_main_recycler"/>
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/siritori_main_list_cell.xml
+++ b/app/src/main/res/layout/siritori_main_list_cell.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                             xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
+                                             android:layout_width="match_parent"
+                                             android:layout_height="wrap_content">
+    <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" app:layout_constraintTop_toTopOf="parent"
+    >
+        <EditText
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:inputType="textPersonName"
+                android:text="Name"
+                android:ems="10"
+                android:id="@+id/siritori_keyword" android:layout_weight="1"/>
+        <EditText
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:inputType="textPersonName"
+                android:text="Name"
+                android:ems="10"
+                android:id="@+id/siritori_idea" android:layout_weight="1"/>
+        <Button
+                android:text="Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" android:id="@+id/button" android:layout_weight="1"/>
+    </LinearLayout>
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
# やったこと
- しりとり法のメイン画面にRecycleView導入
- しりとり法用のRealmObject追加
- ハードコーディングしたキーワードとアイデアを表示できるように設定

# やってないこと
- Realmから呼び出したデータを表示
- しりとりでアイデアを増やす機能の実装
- デザイン

# 参考
https://qiita.com/Todate/items/297bc3e4d0f3d2477ed3
https://qiita.com/saiki-ii/items/78ed73134784f3e5db7e